### PR TITLE
feat: Add sampling params, model size selection, and backend device switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,20 @@ A local web UI for the [Qwen3-TTS](https://huggingface.co/Qwen) model family, bu
 | **Batch** | Queue multiple Custom Voice items and generate them sequentially with per-item progress |
 | **Personas** | Save and manage named voice presets (speaker + language + instruction) for quick reuse |
 
-Models are loaded on demand and can be unloaded individually to free memory. All three models are separate 1.7B checkpoints downloaded from Hugging Face.
+Models are loaded on demand and can be unloaded individually to free memory. Custom Voice and Voice Clone support both 0.6B and 1.7B checkpoints; Voice Design currently uses the 1.7B checkpoint only.
+
+Additional runtime behavior:
+
+- Choose the model size before loading when multiple checkpoints are available
+- Choose the backend device before loading (`cuda:0`, `mps`, or `cpu`, depending on your machine)
+- Loaded tabs show the active runtime as `device / dtype`
+- On Apple Silicon, the app retries once in safer MPS `float32` mode if generation fails with a probability-tensor stability error
 
 ## Requirements
 
 - Python 3.11+
 - [uv](https://github.com/astral-sh/uv)
-- A machine with MPS (Apple Silicon), CUDA, or enough RAM for CPU inference (~4 GB per model)
+- A machine with MPS (Apple Silicon), CUDA, or enough RAM for CPU inference
 
 ## Installation
 
@@ -38,15 +45,22 @@ Then app should auto open itself on [http://localhost:8080](http://localhost:808
 
 ## Models
 
-Models are downloaded automatically from Hugging Face on first load:
+Models are downloaded automatically from Hugging Face once requested in the app:
 
 | Key | Checkpoint |
 |---|---|
-| Custom Voice | `Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice` |
+| Custom Voice | `Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice` or `Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice` |
 | Voice Design | `Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign` |
-| Voice Clone | `Qwen/Qwen3-TTS-12Hz-1.7B-Base` |
+| Voice Clone | `Qwen/Qwen3-TTS-12Hz-1.7B-Base` or `Qwen/Qwen3-TTS-12Hz-0.6B-Base` |
 
-Each model is ~3.4 GB. They are cached locally by Hugging Face after the first download.
+Approximate checkpoint sizes vary by model variant; 0.6B models are substantially smaller than 1.7B models. Downloads are cached locally by Hugging Face after the first load.
+
+## Runtime Notes
+
+- CUDA uses `bfloat16`
+- MPS prefers `float16`, but the app can retry a failing model in `float32` for stability
+- CPU prefers `bfloat16` and falls back to `float32` if needed during model load
+- If Apple Silicon generation still fails on MPS, switch the backend device to `cpu` before loading the model
 
 ## TODOs
 - [x] Add automatic transcription of uploaded audio

--- a/app/audio/tts.py
+++ b/app/audio/tts.py
@@ -142,7 +142,7 @@ class TTSEngine:
         del model
         _empty_device_cache()
 
-    def generate_batch_item(self, item: BatchItem) -> tuple[str, float]:
+    def generate_batch_item(self, item: BatchItem, **kwargs) -> tuple[str, float]:
         last_error: Exception | None = None
         for attempt in range(MAX_RETRIES + 1):
             try:
@@ -151,6 +151,7 @@ class TTSEngine:
                     language=item.language,
                     speaker=item.speaker,
                     instruct=item.instruct,
+                    **kwargs,
                 )
                 gc.collect()
                 _empty_device_cache()
@@ -167,6 +168,7 @@ class TTSEngine:
         language: str = DEFAULT_LANGUAGE,
         speaker: str = DEFAULT_SPEAKER,
         instruct: str = "",
+        **kwargs,
     ) -> tuple[str, float]:
         model = self._models["custom_voice"]
         wavs, sr = model.generate_custom_voice(
@@ -174,6 +176,7 @@ class TTSEngine:
             language=language,
             speaker=speaker,
             instruct=instruct or None,
+            **kwargs,
         )
         return self._save(wavs[0], sr)
 
@@ -182,12 +185,14 @@ class TTSEngine:
         text: str,
         language: str = DEFAULT_LANGUAGE,
         instruct: str = "",
+        **kwargs,
     ) -> tuple[str, float]:
         model = self._models["voice_design"]
         wavs, sr = model.generate_voice_design(
             text=text,
             language=language,
             instruct=instruct,
+            **kwargs,
         )
         return self._save(wavs[0], sr)
 
@@ -197,6 +202,7 @@ class TTSEngine:
         language: str = DEFAULT_LANGUAGE,
         ref_audio: str = "",
         ref_text: str = "",
+        **kwargs,
     ) -> tuple[str, float]:
         model = self._models["voice_clone"]
         wavs, sr = model.generate_voice_clone(
@@ -204,6 +210,7 @@ class TTSEngine:
             language=language,
             ref_audio=ref_audio,
             ref_text=ref_text,
+            **kwargs,
         )
         return self._save(wavs[0], sr)
 

--- a/app/audio/tts.py
+++ b/app/audio/tts.py
@@ -55,17 +55,38 @@ SPEAKER_INFO = {
     "Sohee": {"desc": "Warm Korean female, rich emotion", "lang": "Korean"},
 }
 
-MODEL_IDS = {
-    "custom_voice": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
-    "voice_design": "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign",
-    "voice_clone": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
+MODEL_VARIANTS: dict[str, dict[str, str]] = {
+    "custom_voice": {
+        "1.7B": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+        "0.6B": "Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice",
+    },
+    "voice_design": {
+        "1.7B": "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign",
+    },
+    "voice_clone": {
+        "1.7B": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
+        "0.6B": "Qwen/Qwen3-TTS-12Hz-0.6B-Base",
+    },
 }
 
 MODEL_LABELS = {
-    "custom_voice": "Custom Voice (1.7B)",
-    "voice_design": "Voice Design (1.7B)",
-    "voice_clone": "Voice Clone / Base (1.7B)",
+    "custom_voice": "Custom Voice",
+    "voice_design": "Voice Design",
+    "voice_clone": "Voice Clone / Base",
 }
+
+
+def get_available_model_sizes(key: str) -> list[str]:
+    return list(MODEL_VARIANTS.get(key, {}).keys())
+
+
+def get_model_id(key: str, size: str) -> str:
+    return MODEL_VARIANTS[key][size]
+
+
+def get_model_label(key: str, size: str) -> str:
+    return f"{MODEL_LABELS[key]} ({size})"
+
 
 DEFAULT_SPEAKER = "Ryan"
 DEFAULT_LANGUAGE = "Auto"
@@ -90,18 +111,50 @@ def _detect_device() -> str:
     return "cpu"
 
 
-DEVICE = _detect_device()
-
-
-def _empty_device_cache() -> None:
+def get_available_devices() -> list[str]:
+    devices: list[str] = []
     if torch.cuda.is_available():
-        torch.cuda.empty_cache()
+        devices.append("cuda:0")
+    if platform.system() == "Darwin" and hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        devices.append("mps")
+    devices.append("cpu")
+    return devices
+
+
+DEFAULT_DEVICE = _detect_device()
+
+
+def _empty_device_cache(device: str) -> None:
+    if torch.cuda.is_available():
+        if device.startswith("cuda"):
+            torch.cuda.empty_cache()
     elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-        torch.mps.empty_cache()
+        if device == "mps":
+            torch.mps.empty_cache()
 
 
-def is_model_cached(key: str) -> bool:
-    model_id = MODEL_IDS.get(key)
+def _load_dtype(device: str, model_key: str, force_mps_fp32: bool = False):
+    if device.startswith("cuda"):
+        return torch.bfloat16
+    if device == "mps":
+        if force_mps_fp32:
+            return torch.float32
+        if model_key == "voice_clone":
+            return torch.float32
+        return torch.float16
+    return torch.bfloat16
+
+
+def _is_probability_tensor_error(exc: Exception) -> bool:
+    msg = str(exc).lower()
+    return "probability tensor contains either" in msg
+
+
+def is_model_cached(key: str, size: str) -> bool:
+    model_ids = MODEL_VARIANTS.get(key)
+    if not model_ids:
+        return False
+    model_id = model_ids.get(size)
     if not model_id:
         return False
     try:
@@ -114,25 +167,80 @@ def is_model_cached(key: str) -> bool:
 class TTSEngine:
     def __init__(self) -> None:
         self._models: dict[str, Any] = {}
+        self._loaded_sizes: dict[str, str] = {}
+        self._loaded_dtypes: dict[str, Any] = {}
+        self._device: str = DEFAULT_DEVICE
+        self._mps_force_fp32: dict[str, bool] = {}
+        self._selected_sizes: dict[str, str] = {
+            key: ("1.7B" if "1.7B" in variants else next(iter(variants))) for key, variants in MODEL_VARIANTS.items()
+        }
+
+    def get_available_devices(self) -> list[str]:
+        return get_available_devices()
+
+    def get_device(self) -> str:
+        return self._device
+
+    def set_device(self, device: str) -> None:
+        if device not in self.get_available_devices():
+            raise ValueError(f"Unsupported device '{device}'")
+        if device == self._device:
+            return
+        for key in list(self._models.keys()):
+            self.unload_model(key)
+        self._device = device
+
+    def get_loaded_dtype(self, key: str):
+        return self._loaded_dtypes.get(key)
+
+    def get_selected_size(self, key: str) -> str:
+        return self._selected_sizes[key]
+
+    def set_selected_size(self, key: str, size: str) -> None:
+        if size not in MODEL_VARIANTS[key]:
+            raise ValueError(f"Unsupported model size '{size}' for {key}")
+        self._selected_sizes[key] = size
+
+    def get_loaded_size(self, key: str) -> str | None:
+        return self._loaded_sizes.get(key)
 
     def is_loaded(self, key: str) -> bool:
-        return key in self._models
+        return key in self._models and self._loaded_sizes.get(key) == self._selected_sizes.get(key)
 
     def load_model(self, key: str) -> None:
-        if key in self._models:
+        target_size = self._selected_sizes[key]
+        if key in self._models and self._loaded_sizes.get(key) == target_size:
             return
+        if key in self._models:
+            self.unload_model(key)
         from qwen_tts import Qwen3TTSModel
 
-        model_id = MODEL_IDS[key]
-        model = Qwen3TTSModel.from_pretrained(
-            model_id,
-            device_map=DEVICE,
-            dtype=torch.bfloat16,
-        )
+        model_id = get_model_id(key, target_size)
+        load_dtype = _load_dtype(self._device, key, force_mps_fp32=self._mps_force_fp32.get(key, False))
+        try:
+            model = Qwen3TTSModel.from_pretrained(
+                model_id,
+                device_map=self._device,
+                dtype=load_dtype,
+            )
+        except Exception:
+            if self._device == "cpu" and load_dtype == torch.bfloat16:
+                load_dtype = torch.float32
+                model = Qwen3TTSModel.from_pretrained(
+                    model_id,
+                    device_map=self._device,
+                    dtype=load_dtype,
+                )
+            else:
+                raise
         self._models[key] = model
+        self._loaded_sizes[key] = target_size
+        self._loaded_dtypes[key] = load_dtype
 
     def unload_model(self, key: str) -> None:
         model = self._models.pop(key, None)
+        self._loaded_sizes.pop(key, None)
+        self._loaded_dtypes.pop(key, None)
         if model is None:
             return
         try:
@@ -140,7 +248,18 @@ class TTSEngine:
         except Exception:
             pass
         del model
-        _empty_device_cache()
+        _empty_device_cache(self._device)
+
+    def _run_with_stability_retry(self, key: str, fn):
+        try:
+            return fn()
+        except RuntimeError as exc:
+            if self._device == "mps" and not self._mps_force_fp32.get(key, False) and _is_probability_tensor_error(exc):
+                self._mps_force_fp32[key] = True
+                self.unload_model(key)
+                self.load_model(key)
+                return fn()
+            raise
 
     def generate_batch_item(self, item: BatchItem, **kwargs) -> tuple[str, float]:
         last_error: Exception | None = None
@@ -154,7 +273,7 @@ class TTSEngine:
                     **kwargs,
                 )
                 gc.collect()
-                _empty_device_cache()
+                _empty_device_cache(self._device)
                 return result
             except (TimeoutError, RuntimeError) as e:
                 last_error = e
@@ -170,13 +289,15 @@ class TTSEngine:
         instruct: str = "",
         **kwargs,
     ) -> tuple[str, float]:
-        model = self._models["custom_voice"]
-        wavs, sr = model.generate_custom_voice(
-            text=text,
-            language=language,
-            speaker=speaker,
-            instruct=instruct or None,
-            **kwargs,
+        wavs, sr = self._run_with_stability_retry(
+            "custom_voice",
+            lambda: self._models["custom_voice"].generate_custom_voice(
+                text=text,
+                language=language,
+                speaker=speaker,
+                instruct=instruct or None,
+                **kwargs,
+            ),
         )
         return self._save(wavs[0], sr)
 
@@ -187,12 +308,14 @@ class TTSEngine:
         instruct: str = "",
         **kwargs,
     ) -> tuple[str, float]:
-        model = self._models["voice_design"]
-        wavs, sr = model.generate_voice_design(
-            text=text,
-            language=language,
-            instruct=instruct,
-            **kwargs,
+        wavs, sr = self._run_with_stability_retry(
+            "voice_design",
+            lambda: self._models["voice_design"].generate_voice_design(
+                text=text,
+                language=language,
+                instruct=instruct,
+                **kwargs,
+            ),
         )
         return self._save(wavs[0], sr)
 
@@ -204,13 +327,15 @@ class TTSEngine:
         ref_text: str = "",
         **kwargs,
     ) -> tuple[str, float]:
-        model = self._models["voice_clone"]
-        wavs, sr = model.generate_voice_clone(
-            text=text,
-            language=language,
-            ref_audio=ref_audio,
-            ref_text=ref_text,
-            **kwargs,
+        wavs, sr = self._run_with_stability_retry(
+            "voice_clone",
+            lambda: self._models["voice_clone"].generate_voice_clone(
+                text=text,
+                language=language,
+                ref_audio=ref_audio,
+                ref_text=ref_text,
+                **kwargs,
+            ),
         )
         return self._save(wavs[0], sr)
 

--- a/app/ui/batch.py
+++ b/app/ui/batch.py
@@ -3,7 +3,7 @@ from nicegui import run, ui
 from app.audio.personas import persona_store
 from app.audio.tts import LANGUAGES, SPEAKERS, BatchItem, engine
 from app.ui.events import model_changed, personas_changed
-from app.ui.layout import empty_state, generation_result, model_gate, model_status_bar
+from app.ui.layout import empty_state, generation_result, model_gate, model_status_bar, sampling_controls
 
 
 def batch_tab():
@@ -72,7 +72,11 @@ def batch_tab():
 
         items_editor()
 
+        with ui.expansion("Sampling Parameters", icon="tune").classes("w-full").props("dense header-class=text-sm"):
+            get_sampling_kwargs = sampling_controls()
+
         async def generate_all():
+            sampling_kwargs = get_sampling_kwargs()
             snapshot = [
                 BatchItem(
                     text=i.text,
@@ -142,7 +146,7 @@ def batch_tab():
                 progress_label.text = f"{i} / {len(valid)} complete"
 
                 try:
-                    filename, duration = await run.io_bound(engine.generate_batch_item, item)
+                    filename, duration = await run.io_bound(engine.generate_batch_item, item, **sampling_kwargs)
                     ref["running"].set_visibility(False)
                     ref["success"].set_visibility(True)
                     with ref["audio"]:

--- a/app/ui/custom_voice.py
+++ b/app/ui/custom_voice.py
@@ -3,7 +3,14 @@ from nicegui import run, ui
 from app.audio.personas import Persona, now_iso, persona_store
 from app.audio.tts import DEFAULT_LANGUAGE, DEFAULT_SPEAKER, LANGUAGES, SPEAKER_INFO, SPEAKERS, engine
 from app.ui.events import personas_changed
-from app.ui.layout import generation_error, generation_result, generation_spinner, model_gate, model_status_bar
+from app.ui.layout import (
+    generation_error,
+    generation_result,
+    generation_spinner,
+    model_gate,
+    model_status_bar,
+    sampling_controls,
+)
 
 
 def custom_voice_tab():
@@ -65,6 +72,9 @@ def custom_voice_tab():
             .props("filled")
         )
 
+        with ui.expansion("Sampling Parameters", icon="tune").classes("w-full").props("dense header-class=text-sm"):
+            get_sampling_kwargs = sampling_controls()
+
         result_area = ui.column().classes("w-full")
 
         async def generate():
@@ -79,6 +89,7 @@ def custom_voice_tab():
                     language=language.value or DEFAULT_LANGUAGE,
                     speaker=speaker.value or DEFAULT_SPEAKER,
                     instruct=instruct.value or "",
+                    **get_sampling_kwargs(),
                 )
                 result_area.clear()
                 with result_area:

--- a/app/ui/layout.py
+++ b/app/ui/layout.py
@@ -4,7 +4,13 @@ from typing import Any
 from nicegui import app as nicegui_app
 from nicegui import run, ui
 
-from app.audio.tts import MODEL_IDS, MODEL_LABELS, engine, is_model_cached
+from app.audio.tts import (
+    engine,
+    get_available_model_sizes,
+    get_model_id,
+    get_model_label,
+    is_model_cached,
+)
 from app.config import OUTPUT_DIR
 from app.ui.events import model_changed
 
@@ -63,10 +69,13 @@ def generation_spinner(result_area, message: str) -> None:
 
 
 def generation_error(result_area, error: Exception) -> None:
+    message = str(error)
+    if "probability tensor contains either" in message.lower():
+        message = f"{message} Try lower sampling values, and on Apple Silicon switch model backend to CPU if MPS remains unstable."
     result_area.clear()
     with result_area:
-        ui.label(f"Error: {error}").classes("text-red-500")
-    ui.notify(str(error), type="negative")
+        ui.label(f"Error: {message}").classes("text-red-500")
+    ui.notify(message, type="negative")
 
 
 def generation_result(filename: str, duration: float):
@@ -85,11 +94,46 @@ def generation_result(filename: str, duration: float):
 
 
 def model_gate(model_key: str, on_done: Callable) -> None:
-    cached = is_model_cached(model_key)
-    label = MODEL_LABELS[model_key]
-    model_id = MODEL_IDS[model_key]
+    model_sizes = get_available_model_sizes(model_key)
+    selected_size = engine.get_selected_size(model_key)
+    available_devices = engine.get_available_devices()
+    selected_device = engine.get_device()
+    cached = is_model_cached(model_key, selected_size)
+    label = get_model_label(model_key, selected_size)
+    model_id = get_model_id(model_key, selected_size)
 
     with ui.column().classes("w-full items-center py-10 gap-4"):
+        if len(model_sizes) > 1:
+            size_select = (
+                ui.select(model_sizes, value=selected_size, label="Model Size").classes("w-44").props("filled")
+            )
+
+            def _change_size(e):
+                try:
+                    engine.set_selected_size(model_key, str(e.value))
+                    on_done()
+                except Exception as exc:
+                    ui.notify(str(exc), type="negative")
+
+            size_select.on_value_change(_change_size)
+
+        if len(available_devices) > 1:
+            device_select = (
+                ui.select(available_devices, value=selected_device, label="Backend Device")
+                .classes("w-44")
+                .props("filled")
+            )
+
+            def _change_device(e):
+                try:
+                    engine.set_device(str(e.value))
+                    model_changed.emit(model_key)
+                    on_done()
+                except Exception as exc:
+                    ui.notify(str(exc), type="negative")
+
+            device_select.on_value_change(_change_device)
+
         if cached:
             ui.icon("memory").classes("text-5xl text-stone-400")
             ui.label("Model downloaded but not loaded").classes(
@@ -133,16 +177,22 @@ def model_gate(model_key: str, on_done: Callable) -> None:
 
 def model_status_bar(model_key: str, on_unload: Callable) -> None:
     """Thin status bar shown at the top of a tab when its model is loaded."""
-    label = MODEL_LABELS[model_key]
+    selected_size = engine.get_selected_size(model_key)
+    label = get_model_label(model_key, selected_size)
+    device = engine.get_device()
+    loaded_dtype = engine.get_loaded_dtype(model_key)
+    dtype_text = str(loaded_dtype).replace("torch.", "") if loaded_dtype is not None else "unknown"
 
     with (
         ui.row()
         .classes("w-full items-center justify-between px-3 py-1 rounded-lg mb-3")
         .style("background: rgba(100, 76, 210, 0.08)")
     ):
-        with ui.row().classes("items-center gap-2"):
+        with ui.row().classes("items-center gap-2 flex-wrap"):
             ui.icon("memory").classes("text-base text-primary")
             ui.label(f"{label} loaded").classes("text-sm text-stone-500")
+            ui.icon("memory").classes("text-xs text-stone-400")
+            ui.label(f"{device} / {dtype_text}").classes("text-xs text-stone-400 font-mono")
 
         spinner = ui.spinner("dots", size="sm", color="primary")
         spinner.set_visibility(False)
@@ -182,40 +232,33 @@ def sampling_controls() -> Callable[[], dict[str, Any]]:
     """
 
     # Main parameters
-    with ui.row().classes("w-full gap-3 flex-wrap"):
-        temperature = (
-            ui.number(
-                label="Temperature",
-                value=SAMPLING_DEFAULTS["temperature"],
+    with ui.row().classes("w-full gap-4 flex-wrap items-end"):
+        with ui.column().classes("flex-1 min-w-56 gap-1"):
+            ui.label("Temperature").classes("text-xs text-stone-500")
+            temperature = ui.slider(
                 min=0.01,
                 max=2.0,
                 step=0.01,
-                format="%.2f",
-            )
-            .classes("flex-1 min-w-36")
-            .props("filled dense")
-        )
-        temperature.tooltip("Sampling temperature — higher values produce more varied speech")
+                value=SAMPLING_DEFAULTS["temperature"],
+            ).props("label-always color=primary")
+            temperature.tooltip("Sampling temperature — higher values produce more varied speech")
 
-        top_p = (
-            ui.number(
-                label="Top P",
-                value=SAMPLING_DEFAULTS["top_p"],
+        with ui.column().classes("flex-1 min-w-56 gap-1"):
+            ui.label("Top P").classes("text-xs text-stone-500")
+            top_p = ui.slider(
                 min=0.0,
                 max=1.0,
                 step=0.01,
-                format="%.2f",
-            )
-            .classes("flex-1 min-w-36")
-            .props("filled dense")
-        )
-        top_p.tooltip("Nucleus sampling — cumulative probability cutoff")
+                value=SAMPLING_DEFAULTS["top_p"],
+            ).props("label-always color=primary")
+            top_p.tooltip("Nucleus sampling — cumulative probability cutoff")
 
+    with ui.row().classes("w-full gap-4 flex-wrap items-end"):
         top_k = (
             ui.number(
                 label="Top K",
                 value=SAMPLING_DEFAULTS["top_k"],
-                min=0,
+                min=1,
                 max=500,
                 step=1,
             )
@@ -224,7 +267,6 @@ def sampling_controls() -> Callable[[], dict[str, Any]]:
         )
         top_k.tooltip("Top-K sampling — number of highest-probability tokens to keep")
 
-    with ui.row().classes("w-full gap-3 flex-wrap"):
         max_new_tokens = (
             ui.number(
                 label="Max New Tokens",
@@ -233,24 +275,23 @@ def sampling_controls() -> Callable[[], dict[str, Any]]:
                 max=8192,
                 step=128,
             )
-            .classes("flex-1 min-w-36")
+            .classes("flex-1 min-w-48")
             .props("filled dense")
         )
         max_new_tokens.tooltip("Maximum number of codec tokens to generate")
 
-        repetition_penalty = (
-            ui.number(
-                label="Repetition Penalty",
+        with ui.column().classes("items-center gap-1 min-w-36"):
+            ui.label("Repetition Penalty").classes("text-xs text-stone-500")
+            repetition_penalty = ui.knob(
                 value=SAMPLING_DEFAULTS["repetition_penalty"],
                 min=1.0,
                 max=2.0,
                 step=0.01,
-                format="%.2f",
+                color="primary",
+                size="72px",
+                show_value=True,
             )
-            .classes("flex-1 min-w-36")
-            .props("filled dense")
-        )
-        repetition_penalty.tooltip("Penalty applied to repeated tokens — higher reduces repetition")
+            repetition_penalty.tooltip("Penalty applied to repeated tokens — higher reduces repetition")
 
     # Subtalker parameters (nested expansion)
     with ui.expansion("Subtalker Parameters").classes("w-full").props("dense header-class=text-xs"):
@@ -259,38 +300,30 @@ def sampling_controls() -> Callable[[], dict[str, Any]]:
             "Only change these if you know what you are doing."
         ).classes("text-xs text-stone-400 mb-2")
 
-        with ui.row().classes("w-full gap-3 flex-wrap"):
-            sub_temperature = (
-                ui.number(
-                    label="Subtalker Temperature",
-                    value=SAMPLING_DEFAULTS["subtalker_temperature"],
+        with ui.row().classes("w-full gap-4 flex-wrap items-end"):
+            with ui.column().classes("flex-1 min-w-48 gap-1"):
+                ui.label("Subtalker Temperature").classes("text-xs text-stone-500")
+                sub_temperature = ui.slider(
                     min=0.01,
                     max=2.0,
                     step=0.01,
-                    format="%.2f",
-                )
-                .classes("flex-1 min-w-36")
-                .props("filled dense")
-            )
+                    value=SAMPLING_DEFAULTS["subtalker_temperature"],
+                ).props("label color=secondary")
 
-            sub_top_p = (
-                ui.number(
-                    label="Subtalker Top P",
-                    value=SAMPLING_DEFAULTS["subtalker_top_p"],
+            with ui.column().classes("flex-1 min-w-48 gap-1"):
+                ui.label("Subtalker Top P").classes("text-xs text-stone-500")
+                sub_top_p = ui.slider(
                     min=0.0,
                     max=1.0,
                     step=0.01,
-                    format="%.2f",
-                )
-                .classes("flex-1 min-w-36")
-                .props("filled dense")
-            )
+                    value=SAMPLING_DEFAULTS["subtalker_top_p"],
+                ).props("label color=secondary")
 
             sub_top_k = (
                 ui.number(
                     label="Subtalker Top K",
                     value=SAMPLING_DEFAULTS["subtalker_top_k"],
-                    min=0,
+                    min=1,
                     max=500,
                     step=1,
                 )
@@ -319,6 +352,10 @@ def sampling_controls() -> Callable[[], dict[str, Any]]:
         ui.button("Reset to defaults", icon="restart_alt", on_click=_reset).props("flat dense color=primary size=sm")
 
     def get_kwargs() -> dict[str, Any]:
-        return {key: ctrl.value for key, ctrl in all_controls.items()}
+        kwargs = {key: ctrl.value for key, ctrl in all_controls.items()}
+        kwargs["top_k"] = int(kwargs["top_k"])
+        kwargs["subtalker_top_k"] = int(kwargs["subtalker_top_k"])
+        kwargs["max_new_tokens"] = int(kwargs["max_new_tokens"])
+        return kwargs
 
     return get_kwargs

--- a/app/ui/layout.py
+++ b/app/ui/layout.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from typing import Any
 
 from nicegui import app as nicegui_app
 from nicegui import run, ui
@@ -155,3 +156,169 @@ def model_status_bar(model_key: str, on_unload: Callable) -> None:
             on_unload()
 
         btn = ui.button("Unload", icon="eject", on_click=unload).props("flat dense color=negative size=sm")
+
+
+##########################################################################
+# Sampling parameter defaults (same as _merge_generate_kwargs of qwen-tts)
+##########################################################################
+
+SAMPLING_DEFAULTS: dict[str, Any] = {
+    "temperature": 0.9,
+    "top_p": 1.0,
+    "top_k": 50,
+    "max_new_tokens": 2048,
+    "repetition_penalty": 1.05,
+    "subtalker_temperature": 0.9,
+    "subtalker_top_p": 1.0,
+    "subtalker_top_k": 50,
+}
+
+
+def sampling_controls() -> Callable[[], dict[str, Any]]:
+    """Render a collapsible sampling-parameters panel.
+
+    Returns a callable that produces the current parameter values as a
+    ``dict`` suitable for ``**kwargs`` forwarding to the TTS engine.
+    """
+
+    # Main parameters
+    with ui.row().classes("w-full gap-3 flex-wrap"):
+        temperature = (
+            ui.number(
+                label="Temperature",
+                value=SAMPLING_DEFAULTS["temperature"],
+                min=0.01,
+                max=2.0,
+                step=0.01,
+                format="%.2f",
+            )
+            .classes("flex-1 min-w-36")
+            .props("filled dense")
+        )
+        temperature.tooltip("Sampling temperature — higher values produce more varied speech")
+
+        top_p = (
+            ui.number(
+                label="Top P",
+                value=SAMPLING_DEFAULTS["top_p"],
+                min=0.0,
+                max=1.0,
+                step=0.01,
+                format="%.2f",
+            )
+            .classes("flex-1 min-w-36")
+            .props("filled dense")
+        )
+        top_p.tooltip("Nucleus sampling — cumulative probability cutoff")
+
+        top_k = (
+            ui.number(
+                label="Top K",
+                value=SAMPLING_DEFAULTS["top_k"],
+                min=0,
+                max=500,
+                step=1,
+            )
+            .classes("flex-1 min-w-36")
+            .props("filled dense")
+        )
+        top_k.tooltip("Top-K sampling — number of highest-probability tokens to keep")
+
+    with ui.row().classes("w-full gap-3 flex-wrap"):
+        max_new_tokens = (
+            ui.number(
+                label="Max New Tokens",
+                value=SAMPLING_DEFAULTS["max_new_tokens"],
+                min=128,
+                max=8192,
+                step=128,
+            )
+            .classes("flex-1 min-w-36")
+            .props("filled dense")
+        )
+        max_new_tokens.tooltip("Maximum number of codec tokens to generate")
+
+        repetition_penalty = (
+            ui.number(
+                label="Repetition Penalty",
+                value=SAMPLING_DEFAULTS["repetition_penalty"],
+                min=1.0,
+                max=2.0,
+                step=0.01,
+                format="%.2f",
+            )
+            .classes("flex-1 min-w-36")
+            .props("filled dense")
+        )
+        repetition_penalty.tooltip("Penalty applied to repeated tokens — higher reduces repetition")
+
+    # Subtalker parameters (nested expansion)
+    with ui.expansion("Subtalker Parameters").classes("w-full").props("dense header-class=text-xs"):
+        ui.label(
+            "Controls the sub-codec generation stage of the 12 Hz tokenizer. "
+            "Only change these if you know what you are doing."
+        ).classes("text-xs text-stone-400 mb-2")
+
+        with ui.row().classes("w-full gap-3 flex-wrap"):
+            sub_temperature = (
+                ui.number(
+                    label="Subtalker Temperature",
+                    value=SAMPLING_DEFAULTS["subtalker_temperature"],
+                    min=0.01,
+                    max=2.0,
+                    step=0.01,
+                    format="%.2f",
+                )
+                .classes("flex-1 min-w-36")
+                .props("filled dense")
+            )
+
+            sub_top_p = (
+                ui.number(
+                    label="Subtalker Top P",
+                    value=SAMPLING_DEFAULTS["subtalker_top_p"],
+                    min=0.0,
+                    max=1.0,
+                    step=0.01,
+                    format="%.2f",
+                )
+                .classes("flex-1 min-w-36")
+                .props("filled dense")
+            )
+
+            sub_top_k = (
+                ui.number(
+                    label="Subtalker Top K",
+                    value=SAMPLING_DEFAULTS["subtalker_top_k"],
+                    min=0,
+                    max=500,
+                    step=1,
+                )
+                .classes("flex-1 min-w-36")
+                .props("filled dense")
+            )
+
+    # Reset button
+    all_controls = {
+        "temperature": temperature,
+        "top_p": top_p,
+        "top_k": top_k,
+        "max_new_tokens": max_new_tokens,
+        "repetition_penalty": repetition_penalty,
+        "subtalker_temperature": sub_temperature,
+        "subtalker_top_p": sub_top_p,
+        "subtalker_top_k": sub_top_k,
+    }
+
+    def _reset():
+        for key, ctrl in all_controls.items():
+            ctrl.value = SAMPLING_DEFAULTS[key]
+        ui.notify("Reset to defaults", type="info")
+
+    with ui.row().classes("w-full justify-end"):
+        ui.button("Reset to defaults", icon="restart_alt", on_click=_reset).props("flat dense color=primary size=sm")
+
+    def get_kwargs() -> dict[str, Any]:
+        return {key: ctrl.value for key, ctrl in all_controls.items()}
+
+    return get_kwargs

--- a/app/ui/voice_clone.py
+++ b/app/ui/voice_clone.py
@@ -3,7 +3,14 @@ from nicegui import events, run, ui
 from app.audio.transcribe import transcriber
 from app.audio.tts import DEFAULT_LANGUAGE, LANGUAGES, engine
 from app.config import UPLOAD_DIR
-from app.ui.layout import generation_error, generation_result, generation_spinner, model_gate, model_status_bar
+from app.ui.layout import (
+    generation_error,
+    generation_result,
+    generation_spinner,
+    model_gate,
+    model_status_bar,
+    sampling_controls,
+)
 
 
 def voice_clone_tab():
@@ -97,6 +104,9 @@ def voice_clone_tab():
             .props("filled")
         )
 
+        with ui.expansion("Sampling Parameters", icon="tune").classes("w-full").props("dense header-class=text-sm"):
+            get_sampling_kwargs = sampling_controls()
+
         result_area = ui.column().classes("w-full")
 
         async def generate():
@@ -117,6 +127,7 @@ def voice_clone_tab():
                     language=language.value or DEFAULT_LANGUAGE,
                     ref_audio=ref_audio_path["value"],
                     ref_text=ref_text.value,
+                    **get_sampling_kwargs(),
                 )
                 result_area.clear()
                 with result_area:

--- a/app/ui/voice_design.py
+++ b/app/ui/voice_design.py
@@ -1,7 +1,14 @@
 from nicegui import run, ui
 
 from app.audio.tts import DEFAULT_LANGUAGE, LANGUAGES, engine
-from app.ui.layout import generation_error, generation_result, generation_spinner, model_gate, model_status_bar
+from app.ui.layout import (
+    generation_error,
+    generation_result,
+    generation_spinner,
+    model_gate,
+    model_status_bar,
+    sampling_controls,
+)
 
 
 def voice_design_tab():
@@ -41,6 +48,9 @@ def voice_design_tab():
             .props("filled")
         )
 
+        with ui.expansion("Sampling Parameters", icon="tune").classes("w-full").props("dense header-class=text-sm"):
+            get_sampling_kwargs = sampling_controls()
+
         result_area = ui.column().classes("w-full")
 
         async def generate():
@@ -57,6 +67,7 @@ def voice_design_tab():
                     text=text.value,
                     language=language.value or DEFAULT_LANGUAGE,
                     instruct=instruct.value,
+                    **get_sampling_kwargs(),
                 )
                 result_area.clear()
                 with result_area:

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 from nicegui import app, ui
 
-from app.audio.tts import DEVICE
 from app.config import OUTPUT_DIR
 from app.ui.batch import batch_tab
 from app.ui.custom_voice import custom_voice_tab
@@ -34,10 +33,6 @@ def index():
     header()
 
     with ui.column().classes("w-full max-w-2xl mx-auto px-4 py-6 gap-0"):
-        with ui.row().classes("w-full items-center justify-between mb-4"):
-            with ui.column().classes("w-full items-center"):
-                ui.label(f"Running on {DEVICE}").classes("text-xl font-bold")
-
         with (
             ui.tabs()
             .classes("w-full")


### PR DESCRIPTION

- Add sampling controls (temperature, top_p, top_k, max_new_tokens, repetition_penalty)
- Add subtalker sampling parameters in expandable panel
- Add 0.6B/1.7B model size selection for custom_voice and voice_clone
- Add backend device selection (cuda:0 / mps / cpu) before model load
- Implement dynamic dtype selection per backend:
  - CUDA: bfloat16
  - MPS: float16 (float32 for voice_clone or on stability error)
  - CPU: bfloat16 (fallback to float32 if load fails)
- Add automatic MPS retry in float32 on probability tensor errors
- Show loaded runtime info (device/dtype) in model status bar
- Fix top_k min value from 0 to 1 (required for valid sampling)
- Update README with runtime notes